### PR TITLE
Prevent duplicate request handling

### DIFF
--- a/src/Middleware/InjectDetector.php
+++ b/src/Middleware/InjectDetector.php
@@ -28,11 +28,10 @@ class InjectDetector
             // no-op.
         }
 
-        if (! $response instanceof Response) {
-            return $next($request);
+        // Inject the detector when returning an HTTP response
+        if ($response instanceof Response) {
+            $this->detector->injectDetector($request, $response);
         }
-
-        $this->detector->injectDetector($request, $response);
 
         return $response;
     }


### PR DESCRIPTION
If this middleware intercepts a response that is not an `Illuminate\Http\Response` instance the request will be processed twice.  This is tricky when working with Livewire because it will often return an `Illuminate\Http\JsonResponse` while still operating in the "web" middleware stack.   

This PR removes the extra request processing and ensures that the detector will only be injected into HTTP responses. 